### PR TITLE
check for require.main before accessing methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var stack = require('callsite');
 module.exports = function runnable (fnc, defaults, ctx) {
 	var s = stack();
 	// If called directly just run it with the defaults
-	if (require.main.filename === s[1].getFileName()) {
+	if (require.main && require.main.filename === s[1].getFileName()) {
 		return fnc.apply(ctx || null, defaults || []);
 	}
 


### PR DESCRIPTION
not 100% sure why require.main is undefined on ids and pre-prod, but maybe this helps you out
