### PR TITLE
Support for browserify and multiple runnables in one app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 .DS_Store
+test/fixtures/tmp.js

--- a/browserify-prelude.js
+++ b/browserify-prelude.js
@@ -1,0 +1,3 @@
+var fs = require('fs');
+var path = require('path');
+module.exports = fs.readFileSync(path.join(__dirname, 'browserify-prelude.tmpl'), 'utf8');

--- a/browserify-prelude.tmpl
+++ b/browserify-prelude.tmpl
@@ -1,0 +1,47 @@
+(function outer (modules, cache, entry) {
+	// Save the require from previous bundle to this closure if any
+	var previousRequire = typeof require === 'function' && require;
+	var _main;
+
+	function newRequire (name, jumped, momma) {
+		if (!cache[name]) {
+			if (!modules[name]) {
+				// if we cannot find the module within our internal map or
+				// cache jump to the current global require ie. the last bundle
+				// that was added to the page.
+				var currentRequire = typeof require === 'function' && require;
+				if (!jumped && currentRequire) {
+					return currentRequire(name, true, momma);
+				}
+
+				// If there are other bundles on this page the require from the
+				// previous one is saved to 'previousRequire'. Repeat this as
+				// many times as there are bundles until the module is found or
+				// we exhaust the require chain.
+				if (previousRequire) {
+					return previousRequire(name, true, momma);
+				}
+				var err = new Error('Cannot find module \'' + name + '\'');
+				err.code = 'MODULE_NOT_FOUND';
+				throw err;
+			}
+			var m = cache[name] = {
+				exports: {},
+				parent: momma
+			};
+			var req = function (x) {
+				return newRequire(modules[name][1][x] || x, false, m);
+			};
+			req.main = _main = _main || m.exports;
+			modules[name][0].call(m.exports, req, m, m.exports, outer, modules, cache, entry);
+		}
+		return cache[name].exports;
+	}
+	for (var i = 0; i < entry.length; i++) {
+		_main = null;
+		newRequire(entry[i], false, null);
+	}
+
+	// Override the current require with this new one
+	return newRequire;
+})

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
-var stack = require('callsite');
-
 module.exports = function runnable (fnc, defaults, ctx) {
-	var s = stack();
+	// Default context to the parent module
+	ctx = ctx || module.parent;
+
 	// If called directly just run it with the defaults
-	if (require.main.filename === s[1].getFileName()) {
-		return fnc.apply(ctx || null, defaults || []);
+	if (ctx.parent === null) {
+		return fnc.apply((ctx && ctx.exports) || null, defaults || []);
 	}
 
 	// Loaded via require, so just return

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/wesleytodd/runnable#readme",
   "devDependencies": {
+    "browserify": "^13.1.0",
     "happiness": "^5.5.0",
     "mocha": "^2.4.5"
   },

--- a/test/fixtures/multiple.js
+++ b/test/fixtures/multiple.js
@@ -1,0 +1,11 @@
+var runnable = require('../../');
+var index = require('./index');
+
+module.exports = runnable(function multiple (opts) {
+	console.log(opts.beep);
+	index({
+		foo: 'fop'
+	});
+}, [{
+	beep: 'boop'
+}], module);

--- a/test/fixtures/standalone.js
+++ b/test/fixtures/standalone.js
@@ -1,7 +1,7 @@
 var runnable = require('../../');
 
 module.exports = runnable(function index (opts) {
-	console.log(opts.foo);
+	console.log(opts.standalone);
 }, [{
-	foo: 'bar'
-}], module);
+	standalone: 'foobar'
+}]);

--- a/test/index.js
+++ b/test/index.js
@@ -1,28 +1,100 @@
-/* global describe, it*/
+/* global describe, it, afterEach */
 var spawn = require('child_process').spawn;
 var assert = require('assert');
 var path = require('path');
+var fs = require('fs');
+var browserify = require('browserify');
+
+var index = path.join(__dirname, 'fixtures', 'index.js');
+var other = path.join(__dirname, 'fixtures', 'other.js');
+var multiple = path.join(__dirname, 'fixtures', 'multiple.js');
+var standalone = path.join(__dirname, 'fixtures', 'standalone.js');
+var tmp = path.join(__dirname, 'fixtures', 'tmp.js');
+
+// Custom browserify prefix
+var prelude = require('../browserify-prelude');
+
+function bundle (path, done) {
+	var b = browserify(path, {
+		node: true,
+		prelude: prelude
+	}).bundle();
+	b.on('end', function () {
+		done();
+	});
+	b.pipe(fs.createWriteStream(tmp));
+}
+
+function runBundle (path, onData, done) {
+	var p = spawn('node', [path]);
+	var ran = false;
+	var data = new Buffer('');
+	p.stdout.on('data', function (d) {
+		ran = true;
+		data = Buffer.concat([data, d]);
+	});
+	p.on('close', function () {
+		onData(data);
+		assert(ran);
+		done();
+	});
+}
 
 describe('runnable', function () {
-	it('should execute if called directly', function (done) {
-		var p = spawn('node', [path.join(__dirname, 'fixtures', 'index.js')]);
+	afterEach(function () {
+		try {
+			fs.unlinkSync(tmp);
+		} catch (e) {
+			// Ignore errors
+		}
+		/**/
+	});
 
-		p.stdout.on('data', function (d) {
+	it('should execute if called directly', function (done) {
+		runBundle(index, function (d) {
 			assert.equal(d.toString(), 'bar\n');
-		});
-		p.on('close', function () {
-			done();
-		});
+		}, done);
 	});
 
 	it('should execute return if required', function (done) {
-		var p = spawn('node', [path.join(__dirname, 'fixtures', 'other.js')]);
-
-		p.stdout.on('data', function (d) {
+		runBundle(other, function (d) {
 			assert.equal(d.toString(), 'other\n');
+		}, done);
+	});
+
+	it('should execute with multiple runnables in a single app', function (done) {
+		runBundle(multiple, function (d) {
+			assert.equal(d.toString(), 'boop\nfop\n');
+		}, done);
+	});
+
+	it('should execute when not passed a module', function (done) {
+		runBundle(standalone, function (d) {
+			assert.equal(d.toString(), 'foobar\n');
+		}, done);
+	});
+
+	it('should work when called directly in a browserified bundle', function (done) {
+		bundle(index, function () {
+			runBundle(tmp, function (d) {
+				assert.equal(d.toString(), 'bar\n');
+			}, done);
 		});
-		p.on('close', function () {
-			done();
+	});
+
+	it('should work when required in a browserified bundle', function (done) {
+		bundle(other, function () {
+			runBundle(tmp, function (d) {
+				assert.equal(d.toString(), 'other\n');
+			}, done);
+		});
+	});
+
+	it('should work when required in a browserified bundle with multiple runnables', function (done) {
+		bundle(multiple, function () {
+			runBundle(tmp, function (d) {
+				assert.equal(d.toString(), 'boop\nfop\n');
+			}, done);
 		});
 	});
 });


### PR DESCRIPTION
Required changing back to old methodology for checking, but also turns out that this module cannot serve its purpose in all the use cases without being provided the parent module directly.  So that is what this changes to, thus a breaking change and major version bump. 
